### PR TITLE
docs: add getSlug() method and usage examples to API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ class LivewireComponentExample extends Component
 | **Methods**                     	 | Description                                                 	| Parameters         	|
 |-----------------------------------|-------------------------------------------------------------	|--------------------	|
 | generateUrl()                   	 | Generate manually the URL                                   	|                    	|
+| getSlug()                       	 | Get the URL for a specific language in relative or absolute format | ?string $language = '', bool $relative = true |
 | urlStrategy                     	 | The strategy for creating the URL for the model             	| $language, $locale 	|
 | isAutoGenerateUrls()            	 | Disable generating urls on creation, globally for the model 	|                    	|
 | disableGeneratingUrlsOnCreate() 	 | Disable generating urls on creation                         	|                    	|
@@ -177,6 +178,25 @@ class LivewireComponentExample extends Component
 | absolute_url                    	 | The absolute url, including the domain                      	|                    	|
 | **Relations**                   	 |                                                             	|                    	|
 | urls()                          	 | All the active urls, related to the current model           	|                    	|
+
+### Getting Model URLs
+
+```php
+// Get relative URL for current locale
+$model->relative_url; // e.g., "my-product-name"
+
+// Get absolute URL for current locale
+$model->absolute_url; // e.g., "https://example.com/my-product-name"
+
+// Get URL for specific language (relative)
+$model->getSlug('en', true); // e.g., "my-product-name"
+
+// Get URL for specific language (absolute)
+$model->getSlug('en', false); // e.g., "https://example.com/my-product-name"
+
+// Get URL for current locale (defaults to app locale)
+$model->getSlug(); // e.g., "my-product-name"
+```
 
 ## Commands
 ### urls:generate


### PR DESCRIPTION
This PR adds the missing `getSlug()` method to the API documentation and includes practical usage examples for getting model URLs.

**Changes:**
- Added `getSlug()` method to API table with parameter descriptions
- Added "Getting Model URLs" section with code examples
- Documented usage of `relative_url` and `absolute_url` attributes

Closes #5

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added getSlug() to the API reference with example usage.
  - Introduced a “Getting Model URLs” subsection showing how to retrieve relative and absolute URLs.
  - Included examples for language-specific URLs and default fallbacks.
  - Updated the API table to reflect the new entry and improve discoverability.
  - Documentation-only update; no functional or behavioral changes to the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->