### PR TITLE
fix: change slug column from varchar(255) to text

### DIFF
--- a/database/migrations/create_unique_urls_table.php.stub
+++ b/database/migrations/create_unique_urls_table.php.stub
@@ -10,7 +10,7 @@ return new class extends Migration
     {
         Schema::create('urls', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('slug')->unique()->index();
+            $table->text('slug')->unique()->index();
             $table->string('language')->index();
             $table->string('controller');
             $table->string('method')->default('view');


### PR DESCRIPTION
Change slug column from string() to text() to support URLs longer than 255 characters. According to sitemap specifications, URLs can be up to 2048 characters (excluding domain).

Fixes #13

Generated with [Claude Code](https://claude.ai/code)