### PR TITLE
feat: add exception for models with conflicting url/urls columns

### DIFF
--- a/src/HasUniqueUrls.php
+++ b/src/HasUniqueUrls.php
@@ -19,6 +19,55 @@ trait HasUniqueUrls
     abstract public function urlHandler(): array;
 
     /**
+     * Initialize the HasUniqueUrls trait for an instance.
+     *
+     * @throws Exception
+     */
+    public function initializeHasUniqueUrls(): void
+    {
+        $this->checkForConflictingAttributes();
+    }
+
+    /**
+     * Check if the model has conflicting 'url' or 'urls' attributes.
+     *
+     * @throws Exception
+     */
+    private function checkForConflictingAttributes(): void
+    {
+        $conflictingAttributes = ['url', 'urls'];
+        $modelClass = get_class($this);
+
+        foreach ($conflictingAttributes as $attribute) {
+            // Check if attribute exists in fillable, guarded, or as a database column
+            if ($this->hasColumn($attribute)) {
+                throw new Exception(
+                    "Model [{$modelClass}] has a conflicting column '{$attribute}'. " .
+                    "The HasUniqueUrls trait uses 'urls' as a relationship name and provides 'relative_url' and 'absolute_url' attributes. " .
+                    "Please rename the '{$attribute}' column in your model to avoid conflicts."
+                );
+            }
+        }
+    }
+
+    /**
+     * Check if the model has a specific column.
+     */
+    private function hasColumn(string $column): bool
+    {
+        try {
+            // Check if the table exists and has the column
+            if ($this->getConnection()->getSchemaBuilder()->hasColumn($this->getTable(), $column)) {
+                return true;
+            }
+        } catch (\Exception $e) {
+            // If we can't check the schema (e.g., during testing without migrations), skip the check
+        }
+
+        return false;
+    }
+
+    /**
      * Generate a unique URL for the model.
      *
      * @throws Exception

--- a/tests/HasUniqueUrlsTest.php
+++ b/tests/HasUniqueUrlsTest.php
@@ -181,7 +181,7 @@ test('12. Check if exception is thrown when model has conflicting url column', f
     });
 
     // Create a model class that uses HasUniqueUrls trait
-    $modelClass = new class extends \Illuminate\Database\Eloquent\Model {
+    $modelClass = new class () extends \Illuminate\Database\Eloquent\Model {
         use \Vlados\LaravelUniqueUrls\HasUniqueUrls;
 
         protected $table = 'models_with_url_column';
@@ -203,7 +203,7 @@ test('12. Check if exception is thrown when model has conflicting url column', f
         }
     };
 
-    expect(fn() => $modelClass::create(['name' => 'test', 'url' => 'test-url']))
+    expect(fn () => $modelClass::create(['name' => 'test', 'url' => 'test-url']))
         ->toThrow(Exception::class, "has a conflicting column 'url'");
 
     Schema::dropIfExists('models_with_url_column');
@@ -218,7 +218,7 @@ test('13. Check if exception is thrown when model has conflicting urls column', 
     });
 
     // Create a model class that uses HasUniqueUrls trait
-    $modelClass = new class extends \Illuminate\Database\Eloquent\Model {
+    $modelClass = new class () extends \Illuminate\Database\Eloquent\Model {
         use \Vlados\LaravelUniqueUrls\HasUniqueUrls;
 
         protected $table = 'models_with_urls_column';
@@ -240,7 +240,7 @@ test('13. Check if exception is thrown when model has conflicting urls column', 
         }
     };
 
-    expect(fn() => $modelClass::create(['name' => 'test', 'urls' => 'test-urls']))
+    expect(fn () => $modelClass::create(['name' => 'test', 'urls' => 'test-urls']))
         ->toThrow(Exception::class, "has a conflicting column 'urls'");
 
     Schema::dropIfExists('models_with_urls_column');

--- a/tests/HasUniqueUrlsTest.php
+++ b/tests/HasUniqueUrlsTest.php
@@ -181,30 +181,32 @@ test('12. Check if exception is thrown when model has conflicting url column', f
     });
 
     // Create a model class that uses HasUniqueUrls trait
-    $modelClass = new class () extends \Illuminate\Database\Eloquent\Model {
-        use \Vlados\LaravelUniqueUrls\HasUniqueUrls;
+    // The exception should be thrown during model instantiation
+    expect(function () {
+        $modelClass = new class () extends \Illuminate\Database\Eloquent\Model {
+            use \Vlados\LaravelUniqueUrls\HasUniqueUrls;
 
-        protected $table = 'models_with_url_column';
-        protected $guarded = [];
-        public $timestamps = false;
+            protected $table = 'models_with_url_column';
+            protected $guarded = [];
+            public $timestamps = false;
 
-        public function urlHandler(): array
-        {
-            return [
-                'controller' => \Vlados\LaravelUniqueUrls\Tests\TestUrlHandler::class,
-                'method' => 'view',
-                'arguments' => [],
-            ];
-        }
+            public function urlHandler(): array
+            {
+                return [
+                    'controller' => \Vlados\LaravelUniqueUrls\Tests\TestUrlHandler::class,
+                    'method' => 'view',
+                    'arguments' => [],
+                ];
+            }
 
-        public function urlStrategy($language, $locale): string
-        {
-            return \Illuminate\Support\Str::slug($this->name);
-        }
-    };
+            public function urlStrategy($language, $locale): string
+            {
+                return \Illuminate\Support\Str::slug($this->name);
+            }
+        };
 
-    expect(fn () => $modelClass::create(['name' => 'test', 'url' => 'test-url']))
-        ->toThrow(Exception::class, "has a conflicting column 'url'");
+        $modelClass::create(['name' => 'test', 'url' => 'test-url']);
+    })->toThrow(Exception::class, "has a conflicting column 'url'");
 
     Schema::dropIfExists('models_with_url_column');
 });
@@ -218,30 +220,32 @@ test('13. Check if exception is thrown when model has conflicting urls column', 
     });
 
     // Create a model class that uses HasUniqueUrls trait
-    $modelClass = new class () extends \Illuminate\Database\Eloquent\Model {
-        use \Vlados\LaravelUniqueUrls\HasUniqueUrls;
+    // The exception should be thrown during model instantiation
+    expect(function () {
+        $modelClass = new class () extends \Illuminate\Database\Eloquent\Model {
+            use \Vlados\LaravelUniqueUrls\HasUniqueUrls;
 
-        protected $table = 'models_with_urls_column';
-        protected $guarded = [];
-        public $timestamps = false;
+            protected $table = 'models_with_urls_column';
+            protected $guarded = [];
+            public $timestamps = false;
 
-        public function urlHandler(): array
-        {
-            return [
-                'controller' => \Vlados\LaravelUniqueUrls\Tests\TestUrlHandler::class,
-                'method' => 'view',
-                'arguments' => [],
-            ];
-        }
+            public function urlHandler(): array
+            {
+                return [
+                    'controller' => \Vlados\LaravelUniqueUrls\Tests\TestUrlHandler::class,
+                    'method' => 'view',
+                    'arguments' => [],
+                ];
+            }
 
-        public function urlStrategy($language, $locale): string
-        {
-            return \Illuminate\Support\Str::slug($this->name);
-        }
-    };
+            public function urlStrategy($language, $locale): string
+            {
+                return \Illuminate\Support\Str::slug($this->name);
+            }
+        };
 
-    expect(fn () => $modelClass::create(['name' => 'test', 'urls' => 'test-urls']))
-        ->toThrow(Exception::class, "has a conflicting column 'urls'");
+        $modelClass::create(['name' => 'test', 'urls' => 'test-urls']);
+    })->toThrow(Exception::class, "has a conflicting column 'urls'");
 
     Schema::dropIfExists('models_with_urls_column');
 });


### PR DESCRIPTION
## Summary
- Add validation in HasUniqueUrls trait initialization
- Check if model has 'url' or 'urls' database columns
- Throw descriptive exception with guidance on fixing conflicts
- Add tests to verify exception behavior

Fixes #67

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Adds automatic detection of conflicting URL-related columns and surfaces clear, user-friendly errors during initialization.
- Bug Fixes
  - Prevents hidden conflicts with URL fields from causing unexpected behavior by validating schema access safely and failing fast with descriptive messages.
- Tests
  - Adds tests ensuring exceptions are raised for conflicting column names and that error messages reference the offending column.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->